### PR TITLE
Fix code scanning alert no. 4: Reflected cross-site scripting

### DIFF
--- a/packages/api-plugin/src/generators/trpc-api-generator/files/package.json
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/package.json
@@ -57,7 +57,8 @@
     "superjson": "^1.12.2",
     "trpc-playground": "^1.0.4",
     "znv": "^0.4.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "escape-html": "^1.0.3"
   },
   "files": [
     "build"

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/api/AdminApi.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/api/AdminApi.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt'
 import type { NextFunction, Request, Response, Router } from 'express'
 import { getIronSession } from 'iron-session'
 import * as trpcPlayground from 'trpc-playground/handlers/express'
+import escape from 'escape-html'
 
 import { ensureAdmin } from '@/auth'
 
@@ -77,8 +78,9 @@ export class AdminApi extends Route {
 
   private getLogin(): AdminHandler {
     return (req: Request, res: Response) => {
+      const sanitizedQueryParams = escape(this.getRequestQueryParams(req))
       res.send(
-        loginForm.replace('{queryParams}', this.getRequestQueryParams(req)),
+        loginForm.replace('{queryParams}', sanitizedQueryParams),
       )
     }
   }


### PR DESCRIPTION
Fixes [https://github.com/VersoriumX/OPX/security/code-scanning/4](https://github.com/VersoriumX/OPX/security/code-scanning/4)

To fix the reflected cross-site scripting vulnerability, we need to sanitize the user input before incorporating it into the HTML response. The best way to do this is to use a library that provides HTML escaping functionality. This will ensure that any potentially malicious characters in the query parameters are properly escaped, preventing the execution of injected scripts.

We will:
1. Import the `escape-html` library.
2. Use the `escape` function from this library to sanitize the query parameters before inserting them into the `loginForm` template.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
