### PR TITLE
Fix code scanning alert no. 5: Regular expression injection

### DIFF
--- a/apps/dapp-console-api/package.json
+++ b/apps/dapp-console-api/package.json
@@ -74,7 +74,8 @@
     "superjson": "^1.12.2",
     "trpc-playground": "^1.0.4",
     "viem": "^2.7.20",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "lodash": "^4.17.21"
   },
   "files": [
     "build"

--- a/apps/dapp-console-api/src/constants/envVars.ts
+++ b/apps/dapp-console-api/src/constants/envVars.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 
 import type { Hex } from 'viem'
 import { z } from 'zod'
+import _ from 'lodash'
 
 const getCommaSeparatedValues = (type: string) => {
   try {
@@ -96,10 +97,10 @@ export const envVars = envVarSchema.parse(
         DEPLOYMENT_ENV: 'development',
         DEV_CORS_ALLOWLIST_REG_EXP: getCommaSeparatedValues(
           'DEV_CORS_ALLOWLIST_REG_EXP',
-        ).map((regExp) => new RegExp(regExp)),
+        ).map((regExp) => new RegExp(_.escapeRegExp(regExp))),
         CORS_ALLOWLIST_REG_EXP: getCommaSeparatedValues(
           'CORS_ALLOWLIST_REG_EXP',
-        ).map((regExp) => new RegExp(regExp)),
+        ).map((regExp) => new RegExp(_.escapeRegExp(regExp))),
         IRON_SESSION_SECRET: 'UNKNOWN_IRON_SESSION_PASSWORD_32',
         DB_USER: 'dapp-console-api@oplabs-local-web.iam',
         MIGRATE_DB_USER: 'postgres',


### PR DESCRIPTION
Fixes [https://github.com/VersoriumX/OPX/security/code-scanning/5](https://github.com/VersoriumX/OPX/security/code-scanning/5)

To fix the problem, we need to sanitize the environment variable values before using them to construct regular expressions. The best way to do this is by using a sanitization function such as `_.escapeRegExp` from the lodash library. This function escapes special characters in the input string, making it safe to use in a regular expression.

- Import the lodash library.
- Use `_.escapeRegExp` to sanitize the values retrieved from the environment variables before constructing the regular expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
